### PR TITLE
add more instructions for arm64 macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ Options:
 Latest Release: [https://github.com/mayswind/AriaNg-Native/releases](https://github.com/mayswind/AriaNg-Native/releases)
 
 > **For mac with Apple silicon**  
-> Before starting to install, you need to execute the following command, otherwise the system will show you the file is damaged.
+> Before starting to install, you need to execute the following command, otherwise the system will show you the file is damaged. You should not open the .dmg file and if you did already, eject it before running the command.
 > 
->     $ xattr -r -d com.apple.quarantine AriaNg_Native-macOS-arm64.dmg
+>     $ xattr -r -d com.apple.quarantine AriaNg_Native-*-macOS-arm64.dmg
 
 #### Building from source
 Make sure you have [Node.js](https://nodejs.org/) and [NPM](https://www.npmjs.com/) installed. Then download the source code, and follow these steps.


### PR DESCRIPTION
fix #133

- add warning that dmg should be ejected
- add `*` to match versions