### PR TITLE
Request gzip-compressed responses for HTTP RPC

### DIFF
--- a/main/lib/http.js
+++ b/main/lib/http.js
@@ -9,6 +9,10 @@ const userAgent = 'AriaNg-Native/' + pkgfile.version;
 axios.interceptors.request.use(function (config) {
     config.headers['User-Agent'] = userAgent;
 
+    if (!config.headers['Accept-Encoding']) {
+        config.headers['Accept-Encoding'] = 'gzip';
+    }
+
     return config;
 }, function (error) {
     return Promise.reject(error);


### PR DESCRIPTION
## What

Set a default `Accept-Encoding: gzip` header on HTTP RPC requests in the Electron main process (`main/lib/http.js`).

## Why

aria2's RPC server, when built with zlib, gzip-compresses HTTP responses if the client advertises `Accept-Encoding: gzip`. Status payloads (e.g. `tellStatus` / `tellActive` over many tasks) are sizable JSON, so requesting compression noticeably cuts response bandwidth.

axios decompresses the response transparently in the main process, so the renderer/RPC layer needs no changes.

## Details

- The header is only set when not already present, so a user-defined custom request header can still override it.
- This affects only the **HTTP/HTTPS** RPC transport. The **WebSocket** transport (`main/lib/websocket.js`) does not use HTTP content negotiation — aria2 serves uncompressed WebSocket frames and implements no `permessage-deflate` — so it is intentionally left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)